### PR TITLE
Add stacktrace to reduction response

### DIFF
--- a/fia_api/core/model.py
+++ b/fia_api/core/model.py
@@ -64,9 +64,10 @@ class Script(Base):
     __tablename__ = "scripts"
     script: Mapped[str] = mapped_column(String())
     sha: Mapped[Optional[str]] = mapped_column(String())
+    script_hash: Mapped[str] = mapped_column(String())
 
     def __repr__(self) -> str:
-        return f"Script(id={self.id}, sha='{self.sha}', value='{self.script}')"
+        return f"Script(id={self.id}, sha='{self.sha}', script_hash='{self.script_hash}', value='{self.script}')"
 
 
 class Reduction(Base):
@@ -81,6 +82,7 @@ class Reduction(Base):
     reduction_status_message: Mapped[Optional[str]] = mapped_column(String())
     reduction_inputs: Mapped[JSONB] = mapped_column(JSONB)
     reduction_outputs: Mapped[Optional[str]] = mapped_column(String())
+    stacktrace: Mapped[Optional[str]] = mapped_column(String())
     script_id: Mapped[Optional[int]] = mapped_column(ForeignKey("scripts.id"))
     script: Mapped[Optional["Script"]] = relationship("Script", lazy="joined")
     runs: Mapped[List[Run]] = relationship(

--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -22,7 +22,6 @@ class ScriptResponse(BaseModel):
     """
     ScriptResponse returns from the API a script value
     """
-
     value: str
 
 
@@ -83,6 +82,7 @@ class ReductionResponse(BaseModel):
     reduction_status_message: Optional[str]
     reduction_inputs: Any
     reduction_outputs: Optional[str]
+    stacktrace: Optional[str]
     script: Optional[ScriptResponse]
 
     @staticmethod
@@ -101,6 +101,7 @@ class ReductionResponse(BaseModel):
             reduction_inputs=reduction.reduction_inputs,
             reduction_outputs=reduction.reduction_outputs,
             script=script,
+            stacktrace=reduction.stacktrace,
             id=reduction.id,
         )
 
@@ -129,5 +130,6 @@ class ReductionWithRunsResponse(ReductionResponse):
             reduction_outputs=reduction.reduction_outputs,
             script=script,
             id=reduction.id,
+            stacktrace=reduction.stacktrace,
             runs=[RunResponse.from_run(run) for run in reduction.runs],
         )

--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -22,6 +22,7 @@ class ScriptResponse(BaseModel):
     """
     ScriptResponse returns from the API a script value
     """
+
     value: str
 
 

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -27,6 +27,7 @@ REDUCTION = Reduction(
     reduction_inputs={"ei": "auto"},
     reduction_outputs="some output",
     script=Script(script="print('foo')"),
+    stacktrace="some stacktrace",
     runs=[RUN],
 )
 
@@ -63,6 +64,7 @@ def test_reduction_response_from_reduction():
     assert response.reduction_inputs == REDUCTION.reduction_inputs
     assert response.reduction_outputs == REDUCTION.reduction_outputs
     assert response.reduction_status_message == REDUCTION.reduction_status_message
+    assert response.stacktrace == REDUCTION.stacktrace
 
 
 def test_reduction_with_runs_response_from_reduction():


### PR DESCRIPTION
Closes None, but required for use by frontend

## Description
Adds the stacktrace key value pair to the json object returned when asking for a reduction.