### PR TITLE
Filter script for ghp tokens

### DIFF
--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -104,7 +104,7 @@ class ReductionResponse(BaseModel):
         :param reduction: The Reduction to convert
         :return: The ReductionResponse object
         """
-        script = ScriptResponse.from_script(reduction.script.script) if reduction.script else None
+        script = ScriptResponse.from_script(reduction.script) if isinstance(reduction.script, Script) else None
         return ReductionResponse(
             reduction_start=reduction.reduction_start,
             reduction_end=reduction.reduction_end,
@@ -132,7 +132,7 @@ class ReductionWithRunsResponse(ReductionResponse):
         :param reduction: The Reduction to convert
         :return: The ReductionWithRunsResponse Object
         """
-        script = ScriptResponse.from_script(reduction.script.script) if reduction.script else None
+        script = ScriptResponse.from_script(reduction.script) if isinstance(reduction.script, Script) else None
         return ReductionWithRunsResponse(
             reduction_start=reduction.reduction_start,
             reduction_end=reduction.reduction_end,

--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -104,7 +104,7 @@ class ReductionResponse(BaseModel):
         :param reduction: The Reduction to convert
         :return: The ReductionResponse object
         """
-        script = ScriptResponse(value=reduction.script.script) if reduction.script else None
+        script = ScriptResponse.from_script(reduction.script.script) if reduction.script else None
         return ReductionResponse(
             reduction_start=reduction.reduction_start,
             reduction_end=reduction.reduction_end,
@@ -128,11 +128,11 @@ class ReductionWithRunsResponse(ReductionResponse):
     @staticmethod
     def from_reduction(reduction: Reduction) -> ReductionWithRunsResponse:
         """
-        Given a Reduction, return the ReductionWithRunsReponse
+        Given a Reduction, return the ReductionWithRunsResponse
         :param reduction: The Reduction to convert
         :return: The ReductionWithRunsResponse Object
         """
-        script = ScriptResponse(value=reduction.script.script) if reduction.script else None
+        script = ScriptResponse.from_script(reduction.script.script) if reduction.script else None
         return ReductionWithRunsResponse(
             reduction_start=reduction.reduction_start,
             reduction_end=reduction.reduction_end,

--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -9,7 +9,8 @@ from typing import Optional, Any, List
 
 from pydantic import BaseModel
 
-from fia_api.core.model import ReductionState, Reduction, Run
+from fia_api.core.model import ReductionState, Reduction, Run, Script
+from fia_api.core.utility import filter_script_for_tokens
 
 
 class CountResponse(BaseModel):
@@ -24,6 +25,16 @@ class ScriptResponse(BaseModel):
     """
 
     value: str
+
+    @staticmethod
+    def from_script(script: Script) -> ScriptResponse:
+        """
+        Given a script return a ScriptResponse, filtered for tokens.
+        :param script: The script to convert
+        :return: The ScriptResponse object
+        """
+        script_to_send = filter_script_for_tokens(script.script)
+        return ScriptResponse(value=script_to_send)
 
 
 class PreScriptResponse(BaseModel):

--- a/fia_api/core/utility.py
+++ b/fia_api/core/utility.py
@@ -18,3 +18,20 @@ def forbid_path_characters(func: FuncT) -> FuncT:
         return func(arg)
 
     return cast(FuncT, wrapper)
+
+
+def filter_script_for_tokens(script: str) -> str:
+    """
+    Filters out lines that contain tokens i.e. 'ghp_' and 'network.github.api_token' from the script,
+    by cutting that line.
+    :param script: The script to filter
+    :return: The filtered script
+    """
+    script_list = script.splitlines()
+    filtered_script_list = []
+
+    for line in script_list:
+        if "ghp_" not in line and "network.github.api_token" not in line:
+            filtered_script_list.append(line)
+
+    return "\n".join(filtered_script_list)

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -52,12 +52,14 @@ def test_run_response_from_run():
     assert response.instrument_name == RUN.instrument.instrument_name
 
 
-def test_reduction_response_from_reduction():
+@mock.patch("fia_api.core.responses.ScriptResponse.from_script", return_value=ScriptResponse(value="print('foo')"))
+def test_reduction_response_from_reduction(from_script):
     """
     Test that reduction response can be built from reduction
     :return: None
     """
     response = ReductionResponse.from_reduction(REDUCTION)
+    from_script.assert_called_once_with(REDUCTION.script.script)
     assert not hasattr(response, "runs")
     assert response.id == REDUCTION.id
     assert response.reduction_state == REDUCTION.reduction_state
@@ -70,12 +72,14 @@ def test_reduction_response_from_reduction():
     assert response.stacktrace == REDUCTION.stacktrace
 
 
-def test_reduction_with_runs_response_from_reduction():
+@mock.patch("fia_api.core.responses.ScriptResponse.from_script", return_value=ScriptResponse(value="print('foo')"))
+def test_reduction_with_runs_response_from_reduction(from_script):
     """
     Test reduction response can be built to include runs
     :return: None
     """
     response = ReductionWithRunsResponse.from_reduction(REDUCTION)
+    from_script.assert_called_once_with(REDUCTION.script.script)
     assert response.id == REDUCTION.id
     assert response.reduction_state == REDUCTION.reduction_state
     assert response.script.value == REDUCTION.script.script

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -59,7 +59,7 @@ def test_reduction_response_from_reduction(from_script):
     :return: None
     """
     response = ReductionResponse.from_reduction(REDUCTION)
-    from_script.assert_called_once_with(REDUCTION.script.script)
+    from_script.assert_called_once_with(REDUCTION.script)
     assert not hasattr(response, "runs")
     assert response.id == REDUCTION.id
     assert response.reduction_state == REDUCTION.reduction_state
@@ -79,7 +79,7 @@ def test_reduction_with_runs_response_from_reduction(from_script):
     :return: None
     """
     response = ReductionWithRunsResponse.from_reduction(REDUCTION)
-    from_script.assert_called_once_with(REDUCTION.script.script)
+    from_script.assert_called_once_with(REDUCTION.script)
     assert response.id == REDUCTION.id
     assert response.reduction_state == REDUCTION.reduction_state
     assert response.script.value == REDUCTION.script.script

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -3,9 +3,10 @@ Test cases for response objects
 """
 
 import datetime
+from unittest import mock
 
 from fia_api.core.model import Run, Instrument, Reduction, ReductionState, Script
-from fia_api.core.responses import RunResponse, ReductionResponse, ReductionWithRunsResponse
+from fia_api.core.responses import RunResponse, ReductionResponse, ReductionWithRunsResponse, ScriptResponse
 
 RUN = Run(
     filename="filename",
@@ -19,6 +20,8 @@ RUN = Run(
     instrument=Instrument(instrument_name="instrument name"),
 )
 
+SCRIPT = Script(script="print('foo')")
+
 REDUCTION = Reduction(
     id=1,
     reduction_start=datetime.datetime(2000, 1, 1, 1, 1, 1),
@@ -26,7 +29,7 @@ REDUCTION = Reduction(
     reduction_state=ReductionState.SUCCESSFUL,
     reduction_inputs={"ei": "auto"},
     reduction_outputs="some output",
-    script=Script(script="print('foo')"),
+    script=SCRIPT,
     stacktrace="some stacktrace",
     runs=[RUN],
 )
@@ -82,3 +85,14 @@ def test_reduction_with_runs_response_from_reduction():
     assert response.reduction_outputs == REDUCTION.reduction_outputs
     assert response.reduction_status_message == REDUCTION.reduction_status_message
     assert isinstance(response.runs[0], RunResponse)
+
+
+@mock.patch("fia_api.core.responses.filter_script_for_tokens", return_value=SCRIPT.script)
+def test_script_attempts_to_filter_tokens(filter_script_for_tokens):
+    """
+    Test script response calls the util function when calling "from_script"
+    :return: None
+    """
+    response: ScriptResponse = ScriptResponse.from_script(SCRIPT)
+    assert response.value == SCRIPT.script
+    filter_script_for_tokens.assert_called_once_with(SCRIPT.script)

--- a/test/core/test_utility.py
+++ b/test/core/test_utility.py
@@ -48,16 +48,16 @@ def test_no_raise_when_no_bad_characters():
     assert forbid_path_characters(dummy_string_arg_function)("hello") == "hello"
 
 
-ghp_script = (
+GHP_SCRIPT = (
     "from mantid.kernel import ConfigService\n"
     'ConfigService.Instance()["network.github.api_token"] = "ghp_random_token"'
     "\nfrom mantid.simpleapi import *"
 )
-script = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
-expected_script = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
+SCRIPT = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
+EXPECTED_SCRIPT = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
 
 
-@pytest.mark.parametrize("input_script,expected_script", [(ghp_script, expected_script), (script, expected_script)])
+@pytest.mark.parametrize("input_script,expected_script", [(GHP_SCRIPT, EXPECTED_SCRIPT), (SCRIPT, EXPECTED_SCRIPT)])
 def test_filter_script_for_tokens(input_script, expected_script):
     output_script = filter_script_for_tokens(input_script)
 

--- a/test/core/test_utility.py
+++ b/test/core/test_utility.py
@@ -53,12 +53,15 @@ GHP_SCRIPT = (
     'ConfigService.Instance()["network.github.api_token"] = "ghp_random_token"'
     "\nfrom mantid.simpleapi import *"
 )
-SCRIPT = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
-EXPECTED_SCRIPT = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
+SCRIPT = "from mantid.kernel import ConfigService\nfrom mantid.simpleapi import *"
+EXPECTED_SCRIPT = "from mantid.kernel import ConfigService\nfrom mantid.simpleapi import *"
 
 
 @pytest.mark.parametrize("input_script,expected_script", [(GHP_SCRIPT, EXPECTED_SCRIPT), (SCRIPT, EXPECTED_SCRIPT)])
 def test_filter_script_for_tokens(input_script, expected_script):
+    """
+    Test the filter script for tokens
+    """
     output_script = filter_script_for_tokens(input_script)
 
     assert output_script == expected_script

--- a/test/core/test_utility.py
+++ b/test/core/test_utility.py
@@ -48,13 +48,13 @@ def test_no_raise_when_no_bad_characters():
     assert forbid_path_characters(dummy_string_arg_function)("hello") == "hello"
 
 
-ghp_script = ("from mantid.kernel import ConfigService\n"
-              "ConfigService.Instance()[\"network.github.api_token\"] = \"ghp_random_token\""
-              "\nfrom mantid.simpleapi import *")
-script = ("from mantid.kernel import ConfigService"
-          "\nfrom mantid.simpleapi import *")
-expected_script = ("from mantid.kernel import ConfigService"
-                   "\nfrom mantid.simpleapi import *")
+ghp_script = (
+    "from mantid.kernel import ConfigService\n"
+    'ConfigService.Instance()["network.github.api_token"] = "ghp_random_token"'
+    "\nfrom mantid.simpleapi import *"
+)
+script = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
+expected_script = "from mantid.kernel import ConfigService" "\nfrom mantid.simpleapi import *"
 
 
 @pytest.mark.parametrize("input_script,expected_script", [(ghp_script, expected_script), (script, expected_script)])

--- a/test/core/test_utility.py
+++ b/test/core/test_utility.py
@@ -5,7 +5,7 @@ Tests for utility functions
 import pytest
 
 from fia_api.core.exceptions import UnsafePathError
-from fia_api.core.utility import forbid_path_characters
+from fia_api.core.utility import forbid_path_characters, filter_script_for_tokens
 
 
 def dummy_string_arg_function(arg: str) -> str:
@@ -46,3 +46,19 @@ def test_no_raise_when_no_bad_characters():
     :return:
     """
     assert forbid_path_characters(dummy_string_arg_function)("hello") == "hello"
+
+
+ghp_script = ("from mantid.kernel import ConfigService\n"
+              "ConfigService.Instance()[\"network.github.api_token\"] = \"ghp_random_token\""
+              "\nfrom mantid.simpleapi import *")
+script = ("from mantid.kernel import ConfigService"
+          "\nfrom mantid.simpleapi import *")
+expected_script = ("from mantid.kernel import ConfigService"
+                   "\nfrom mantid.simpleapi import *")
+
+
+@pytest.mark.parametrize("input_script,expected_script", [(ghp_script, expected_script), (script, expected_script)])
+def test_filter_script_for_tokens(input_script, expected_script):
+    output_script = filter_script_for_tokens(input_script)
+
+    assert output_script == expected_script


### PR DESCRIPTION
Closes [#324](https://github.com/fiaisis/FIA-API/issues/324)

## Description
I noticed an issue with the scripts being shown to users still containing the ghp token, whilst there are no permissions on the token we use it to increase the download cap for Mantid when downloading Mantid Instrument data inside of containers.