### PR TITLE
Create jobs from new endpoints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,14 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      rabbit-mq:
+        image: "rabbitmq:3.12-management"
+        ports:
+          - "5672:5672"
+          - "15672:15672"
+        env:
+          RABBITMQ_USER: guest
+          RABBITMQ_PASSWORD: guest
 
     steps:
       - name: Check out repository
@@ -119,11 +127,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
 
-      - name: Run tests
+      - name: Run tests (excluding job maker)
         env:
           DATABASE_URL: postgresql://postgres:password@localhost:5432/test_db
         run: |
-          pytest test/e2e --random-order --random-order-bucket=global --cov --cov-report=xml
+          pytest test/e2e --random-order --random-order-bucket=global --cov --cov-report=xml --ignore=test/e2e/test_job_maker.py
+
+      - name: Run test job maker
+        env:
+          DEV_MODE: True
+        run: |
+          pytest test/e2e/test_job_maker.py --random-order --random-order-bucket=global --cov --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/fia_api/core/job_maker.py
+++ b/fia_api/core/job_maker.py
@@ -1,0 +1,55 @@
+import json
+
+
+class JobMaker:
+    def __init__(self):
+        # Connect to Rabbit
+        pass
+
+    def _send_message(self, message: str) -> None:
+        pass
+
+    def rerun_job(self, job_id: int, runner_image: str, script: str, experiment_number: int | None = None,
+                  user_number: int | None = None) -> None:
+        """
+        Default to using experiment_number over user_number
+        :param job_id:
+        :param runner_image:
+        :param script:
+        :param experiment_number:
+        :param user_number:
+        :return: None
+        """
+        json_dict = {
+            "job_id": job_id,
+            "runner_image": runner_image,
+            "script": script
+        }
+        if experiment_number is not None:
+            json_dict["experiment_number"] = experiment_number
+        elif user_number is not None:
+            json_dict["user_number"] = user_number
+        else:
+            raise ValueError("Something needs to own the job, either experiment_number or user_number.")
+        self._send_message(json.dumps(json_dict))
+
+    def simple_job(self, runner_image: str, script: str, experiment_number: int | None = None, user_number: int | None = None) -> None:
+        """
+        Default to using experiment_number over user_number
+        :param runner_image:
+        :param script:
+        :param experiment_number:
+        :param user_number:
+        :return: None
+        """
+        json_dict = {
+            "runner_image": runner_image,
+            "script": script
+        }
+        if experiment_number is not None:
+            json_dict["experiment_number"] = experiment_number
+        elif user_number is not None:
+            json_dict["user_number"] = user_number
+        else:
+            raise ValueError("Something needs to own the job, either experiment_number or user_number.")
+        self._send_message(json.dumps(json_dict))

--- a/fia_api/core/job_maker.py
+++ b/fia_api/core/job_maker.py
@@ -8,7 +8,6 @@ from pika.credentials import PlainCredentials  # type: ignore[import-untyped]
 
 class JobMaker:
     def __init__(self, queue_host: str, username: str, password: str, queue_name: str):
-        # Connect to Rabbit
         credentials = PlainCredentials(username=username, password=password)
         self.connection_parameters = ConnectionParameters(queue_host, 5672, credentials=credentials)
         self.queue_name = queue_name
@@ -49,12 +48,13 @@ class JobMaker:
         user_number: int | None = None,
     ) -> None:
         """
-        Default to using experiment_number over user_number
-        :param job_id:
-        :param runner_image:
-        :param script:
-        :param experiment_number:
-        :param user_number:
+        Submit a rerun job to the scheduled job queue in the message broker. Default to using experiment_number over
+        user_number.
+        :param job_id: The id of the job to be reran
+        :param runner_image: The image used as a runner on the cluster
+        :param script: The script to be used in the runner
+        :param experiment_number: the experiment number of the owner
+        :param user_number: the user number of the owner
         :return: None
         """
         json_dict: dict[str, Any] = {"job_id": job_id, "runner_image": runner_image, "script": script}
@@ -70,11 +70,12 @@ class JobMaker:
         self, runner_image: str, script: str, experiment_number: int | None = None, user_number: int | None = None
     ) -> None:
         """
-        Default to using experiment_number over user_number
-        :param runner_image:
-        :param script:
-        :param experiment_number:
-        :param user_number:
+        Submit a job to the scheduled job queue in the message broker. Default to using experiment_number over
+        user_number.
+        :param runner_image: The image used as a runner on the cluster
+        :param script: The script to be used in the runner
+        :param experiment_number: the experiment number of the owner
+        :param user_number: the user number of the owner
         :return: None
         """
         json_dict: dict[str, Any] = {"runner_image": runner_image, "script": script}

--- a/fia_api/core/job_maker.py
+++ b/fia_api/core/job_maker.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from pika.adapters.blocking_connection import BlockingConnection  # type: ignore[import-untyped]
 from pika.connection import ConnectionParameters  # type: ignore[import-untyped]
@@ -56,7 +57,7 @@ class JobMaker:
         :param user_number:
         :return: None
         """
-        json_dict = {"job_id": job_id, "runner_image": runner_image, "script": script}
+        json_dict: dict[str, Any] = {"job_id": job_id, "runner_image": runner_image, "script": script}
         if experiment_number is not None:
             json_dict["experiment_number"] = experiment_number
         elif user_number is not None:
@@ -76,7 +77,7 @@ class JobMaker:
         :param user_number:
         :return: None
         """
-        json_dict = {"runner_image": runner_image, "script": script}
+        json_dict: dict[str, Any] = {"runner_image": runner_image, "script": script}
         if experiment_number is not None:
             json_dict["experiment_number"] = experiment_number
         elif user_number is not None:

--- a/fia_api/core/job_maker.py
+++ b/fia_api/core/job_maker.py
@@ -9,8 +9,14 @@ class JobMaker:
     def _send_message(self, message: str) -> None:
         pass
 
-    def rerun_job(self, job_id: int, runner_image: str, script: str, experiment_number: int | None = None,
-                  user_number: int | None = None) -> None:
+    def rerun_job(
+        self,
+        job_id: int,
+        runner_image: str,
+        script: str,
+        experiment_number: int | None = None,
+        user_number: int | None = None,
+    ) -> None:
         """
         Default to using experiment_number over user_number
         :param job_id:
@@ -20,11 +26,7 @@ class JobMaker:
         :param user_number:
         :return: None
         """
-        json_dict = {
-            "job_id": job_id,
-            "runner_image": runner_image,
-            "script": script
-        }
+        json_dict = {"job_id": job_id, "runner_image": runner_image, "script": script}
         if experiment_number is not None:
             json_dict["experiment_number"] = experiment_number
         elif user_number is not None:
@@ -33,7 +35,9 @@ class JobMaker:
             raise ValueError("Something needs to own the job, either experiment_number or user_number.")
         self._send_message(json.dumps(json_dict))
 
-    def simple_job(self, runner_image: str, script: str, experiment_number: int | None = None, user_number: int | None = None) -> None:
+    def simple_job(
+        self, runner_image: str, script: str, experiment_number: int | None = None, user_number: int | None = None
+    ) -> None:
         """
         Default to using experiment_number over user_number
         :param runner_image:
@@ -42,10 +46,7 @@ class JobMaker:
         :param user_number:
         :return: None
         """
-        json_dict = {
-            "runner_image": runner_image,
-            "script": script
-        }
+        json_dict = {"runner_image": runner_image, "script": script}
         if experiment_number is not None:
             json_dict["experiment_number"] = experiment_number
         elif user_number is not None:

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -16,7 +16,8 @@ from fia_api.core.repositories import Repo
 from fia_api.core.specifications.job import JobSpecification
 
 
-def job_maker():
+def job_maker() -> JobMaker:
+    """Creates a JobMaker and returns it using env vars"""
     queue_host = os.environ.get("QUEUE_HOST", "localhost")
     queue_name = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
     producer_username = os.environ.get("QUEUE_USER", "guest")

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -127,5 +127,4 @@ def count_jobs() -> int:
 
 
 def get_experiment_number_for_job_id(job_id: int) -> int:
-
     return _REPO.find_one(JobSpecification().by_id(job_id)).owner.experiment_number

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -135,7 +135,7 @@ def get_experiment_number_for_job_id(job_id: int) -> int:
     job = _REPO.find_one(JobSpecification().by_id(job_id))
     if job is not None:
         owner = job.owner
-        if owner is not None:
+        if owner is not None and owner.experiment_number is not None:
             return owner.experiment_number
         raise ValueError("Job has no owner in the DB")
     raise ValueError("No job found with ID in the DB")

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -15,15 +15,14 @@ from fia_api.core.job_maker import JobMaker
 from fia_api.core.repositories import Repo
 from fia_api.core.specifications.job import JobSpecification
 
-QUEUE_HOST = os.environ.get("QUEUE_HOST", "localhost")
-QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
-PRODUCER_USERNAME = os.environ.get("QUEUE_USER", "guest")
-PRODUCER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "guest")
 
-JOB_MAKER = JobMaker(
-    queue_host=QUEUE_HOST, queue_name=QUEUE_NAME, username=PRODUCER_USERNAME, password=PRODUCER_PASSWORD
-)
-
+def job_maker():
+    queue_host = os.environ.get("QUEUE_HOST", "localhost")
+    queue_name = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
+    producer_username = os.environ.get("QUEUE_USER", "guest")
+    producer_password = os.environ.get("QUEUE_PASSWORD", "guest")
+    return JobMaker(queue_host=queue_host, queue_name=queue_name, username=producer_username,
+                    password=producer_password)
 
 class SimpleJob(BaseModel):
     runner_image: str

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -1,6 +1,7 @@
 """
 Service Layer for jobs
 """
+
 import os
 from collections.abc import Sequence
 from typing import Literal

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -124,3 +124,8 @@ def count_jobs() -> int:
     :return: (int) number of jobs
     """
     return _REPO.count(JobSpecification().all())
+
+
+def get_experiment_number_for_job_id(job_id: int) -> int:
+
+    return _REPO.find_one(JobSpecification().by_id(job_id)).owner.experiment_number

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -21,8 +21,10 @@ def job_maker():
     queue_name = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
     producer_username = os.environ.get("QUEUE_USER", "guest")
     producer_password = os.environ.get("QUEUE_PASSWORD", "guest")
-    return JobMaker(queue_host=queue_host, queue_name=queue_name, username=producer_username,
-                    password=producer_password)
+    return JobMaker(
+        queue_host=queue_host, queue_name=queue_name, username=producer_username, password=producer_password
+    )
+
 
 class SimpleJob(BaseModel):
     runner_image: str

--- a/fia_api/core/services/job.py
+++ b/fia_api/core/services/job.py
@@ -127,4 +127,15 @@ def count_jobs() -> int:
 
 
 def get_experiment_number_for_job_id(job_id: int) -> int:
-    return _REPO.find_one(JobSpecification().by_id(job_id)).owner.experiment_number
+    """
+    Given a job id find and return the experiment number attached to it or will raise an exception.
+    :param job_id: (int) The id of the job
+    :return: (int) the experiment number of the job found with the id
+    """
+    job = _REPO.find_one(JobSpecification().by_id(job_id))
+    if job is not None:
+        owner = job.owner
+        if owner is not None:
+            return owner.experiment_number
+        raise ValueError("Job has no owner in the DB")
+    raise ValueError("No job found with ID in the DB")

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -15,6 +15,7 @@ from starlette.background import BackgroundTasks
 from fia_api.core.auth.api_keys import APIKeyBearer
 from fia_api.core.auth.experiments import get_experiments_for_user_number
 from fia_api.core.auth.tokens import JWTBearer, get_user_from_token
+from fia_api.core.job_maker import JobMaker
 from fia_api.core.repositories import test_connection
 from fia_api.core.responses import (
     CountResponse,
@@ -24,7 +25,6 @@ from fia_api.core.responses import (
 )
 from fia_api.core.services.instrument import get_specification_by_instrument_name, update_specification_for_instrument
 from fia_api.core.services.job import (
-    JOB_MAKER,
     RerunJob,
     SimpleJob,
     count_jobs,
@@ -33,6 +33,7 @@ from fia_api.core.services.job import (
     get_experiment_number_for_job_id,
     get_job_by_id,
     get_job_by_instrument,
+    job_maker,
 )
 from fia_api.scripts.acquisition import (
     get_script_by_sha,
@@ -228,7 +229,8 @@ async def count_all_jobs() -> CountResponse:
 
 @ROUTER.post("/job/rerun", tags=["job"])
 async def make_rerun_job(
-    rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
+    rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
+        job_maker: Annotated[JobMaker, Depends(job_maker)]
 ) -> None:
     user = get_user_from_token(credentials.credentials)
     experiment_number = get_experiment_number_for_job_id(rerun_job.job_id)
@@ -238,7 +240,7 @@ async def make_rerun_job(
         if experiment_number not in experiment_numbers:
             # If not staff this is not allowed
             raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
-    JOB_MAKER.rerun_job(
+    job_maker.rerun_job(
         job_id=rerun_job.job_id,
         runner_image=rerun_job.runner_image,
         script=rerun_job.script,
@@ -248,13 +250,14 @@ async def make_rerun_job(
 
 @ROUTER.post("/job/simple", tags=["job"])
 async def make_simple_job(
-    simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
+    simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
+        job_maker: Annotated[JobMaker, Depends(job_maker)]
 ) -> None:
     user = get_user_from_token(credentials.credentials)
     if user.role != "staff":
         # If not staff this is not allowed
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
-    JOB_MAKER.simple_job(runner_image=simple_job.runner_image, script=simple_job.script, user_number=user.user_number)
+    job_maker.simple_job(runner_image=simple_job.runner_image, script=simple_job.script, user_number=user.user_number)
 
 
 @ROUTER.get("/instrument/{instrument_name}/specification", tags=["instrument"], response_model=None)

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -229,8 +229,9 @@ async def count_all_jobs() -> CountResponse:
 
 @ROUTER.post("/job/rerun", tags=["job"])
 async def make_rerun_job(
-    rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
-        job_maker: Annotated[JobMaker, Depends(job_maker)]
+    rerun_job: RerunJob,
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
+    job_maker: Annotated[JobMaker, Depends(job_maker)],
 ) -> None:
     user = get_user_from_token(credentials.credentials)
     experiment_number = get_experiment_number_for_job_id(rerun_job.job_id)
@@ -250,8 +251,9 @@ async def make_rerun_job(
 
 @ROUTER.post("/job/simple", tags=["job"])
 async def make_simple_job(
-    simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
-        job_maker: Annotated[JobMaker, Depends(job_maker)]
+    simple_job: SimpleJob,
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)],
+    job_maker: Annotated[JobMaker, Depends(job_maker)],
 ) -> None:
     user = get_user_from_token(credentials.credentials)
     if user.role != "staff":

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -4,6 +4,7 @@ Module containing the REST endpoints
 
 from __future__ import annotations
 
+import os
 from http import HTTPStatus
 from typing import Annotated, Any, Literal
 
@@ -40,8 +41,15 @@ from fia_api.scripts.acquisition import (
 )
 from fia_api.scripts.pre_script import PreScript
 
+QUEUE_HOST = os.environ.get("QUEUE_HOST", "rabbitmq-cluster.rabbitmq.svc.cluster.local")
+QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
+PRODUCER_USERNAME = os.environ.get("QUEUE_USER", "admin")
+PRODUCER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "password")
+
+JOB_MAKER = JobMaker(queue_host=QUEUE_HOST, queue_name=QUEUE_NAME,
+                     username=PRODUCER_USERNAME, password=PRODUCER_PASSWORD)
+
 ROUTER = APIRouter()
-JOB_MAKER = JobMaker()
 jwt_security = JWTBearer()
 api_key_security = APIKeyBearer()
 

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -46,8 +46,9 @@ QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
 PRODUCER_USERNAME = os.environ.get("QUEUE_USER", "admin")
 PRODUCER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "password")
 
-JOB_MAKER = JobMaker(queue_host=QUEUE_HOST, queue_name=QUEUE_NAME,
-                     username=PRODUCER_USERNAME, password=PRODUCER_PASSWORD)
+JOB_MAKER = JobMaker(
+    queue_host=QUEUE_HOST, queue_name=QUEUE_NAME, username=PRODUCER_USERNAME, password=PRODUCER_PASSWORD
+)
 
 ROUTER = APIRouter()
 jwt_security = JWTBearer()

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -233,7 +233,9 @@ class RerunJob(BaseModel):
 
 
 @ROUTER.post("/job/rerun", tags=["job"])
-async def make_rerun_job(rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]):
+async def make_rerun_job(
+    rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
+):
     user = get_user_from_token(credentials.credentials)
     experiment_number = get_experiment_number_for_job_id(rerun_job.job_id)
     # Forbidden if not staff, and experiment number not related to this user_number's experiment number
@@ -242,7 +244,12 @@ async def make_rerun_job(rerun_job: RerunJob, credentials: Annotated[HTTPAuthori
         if experiment_number not in experiment_numbers:
             # If not staff this is not allowed
             raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
-    JOB_MAKER.rerun_job(job_id=rerun_job.job_id, runner_image=rerun_job.runner_image, script=rerun_job.script, experiment_number=experiment_number)
+    JOB_MAKER.rerun_job(
+        job_id=rerun_job.job_id,
+        runner_image=rerun_job.runner_image,
+        script=rerun_job.script,
+        experiment_number=experiment_number,
+    )
 
 
 class SimpleJob(BaseModel):
@@ -251,7 +258,9 @@ class SimpleJob(BaseModel):
 
 
 @ROUTER.post("/job/simple", tags=["job"])
-async def make_simple_job(simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]):
+async def make_simple_job(
+    simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
+):
     user = get_user_from_token(credentials.credentials)
     if user.role != "staff":
         # If not staff this is not allowed

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -41,10 +41,10 @@ from fia_api.scripts.acquisition import (
 )
 from fia_api.scripts.pre_script import PreScript
 
-QUEUE_HOST = os.environ.get("QUEUE_HOST", "rabbitmq-cluster.rabbitmq.svc.cluster.local")
+QUEUE_HOST = os.environ.get("QUEUE_HOST", "localhost")
 QUEUE_NAME = os.environ.get("EGRESS_QUEUE_NAME", "scheduled-jobs")
-PRODUCER_USERNAME = os.environ.get("QUEUE_USER", "admin")
-PRODUCER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "password")
+PRODUCER_USERNAME = os.environ.get("QUEUE_USER", "guest")
+PRODUCER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "guest")
 
 JOB_MAKER = JobMaker(
     queue_host=QUEUE_HOST, queue_name=QUEUE_NAME, username=PRODUCER_USERNAME, password=PRODUCER_PASSWORD

--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -244,7 +244,7 @@ class RerunJob(BaseModel):
 @ROUTER.post("/job/rerun", tags=["job"])
 async def make_rerun_job(
     rerun_job: RerunJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
-):
+) -> None:
     user = get_user_from_token(credentials.credentials)
     experiment_number = get_experiment_number_for_job_id(rerun_job.job_id)
     # Forbidden if not staff, and experiment number not related to this user_number's experiment number
@@ -269,7 +269,7 @@ class SimpleJob(BaseModel):
 @ROUTER.post("/job/simple", tags=["job"])
 async def make_simple_job(
     simple_job: SimpleJob, credentials: Annotated[HTTPAuthorizationCredentials, Depends(jwt_security)]
-):
+) -> None:
     user = get_user_from_token(credentials.credentials)
     if user.role != "staff":
         # If not staff this is not allowed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "pydantic==2.8.2",
     "db@git+https://github.com/fiaisis/db",
     "uvicorn==0.30.3",
-    "requests==2.32.3"
+    "requests==2.32.3",
+    "pika==1.3.2",
 ]
 
 [project.urls]

--- a/test/core/services/test_job.py
+++ b/test/core/services/test_job.py
@@ -184,4 +184,3 @@ def test_get_experiment_number_from_job_id_expect_raise(mock_repo):
 
     with patch("fia_api.core.services.job.JobSpecification"), pytest.raises(ValueError):  # noqa: PT011
         get_experiment_number_for_job_id(job_id)
-

--- a/test/core/test_job_maker.py
+++ b/test/core/test_job_maker.py
@@ -1,0 +1,166 @@
+import json
+from unittest import mock
+
+import pytest  # type: ignore
+
+from fia_api.core.job_maker import JobMaker
+from test.utils import FIA_FAKER_PROVIDER
+
+faker = FIA_FAKER_PROVIDER
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_send_message(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker.channel = mock.MagicMock()
+    custom_message = str(mock.MagicMock())
+
+    job_maker._send_message(custom_message)
+
+    assert broker.call_count == 2  # noqa: PLR2004
+    assert broker.call_args == [mock.call(), mock.call()]
+    assert job_maker.channel.basic_publish.call_count == 1
+    assert job_maker.channel.basic_publish.call_args == mock.call(exchange="", routing_key="", body=custom_message)
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_rerun_job_experiment_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    job_id = faker.generator.random.randint(1, 10000)
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    experiment_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script, experiment_number=experiment_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
+                                  "experiment_number": experiment_number})))
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_rerun_job_user_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    job_id = faker.generator.random.randint(1, 10000)
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script, user_number=user_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
+                                  "user_number": user_number})))
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_rerun_job_user_and_experiment_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    job_id = faker.generator.random.randint(1, 10000)
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = faker.generator.random.randint(1, 1000000)
+    experiment_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script,
+                        user_number=user_number, experiment_number=experiment_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
+                                  "experiment_number": experiment_number})))
+
+
+def test_rerun_job_user_and_experiment_number_is_none():
+    with mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker"):
+        job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    job_id = faker.generator.random.randint(1, 10000)
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = None
+    experiment_number = None
+
+    with pytest.raises(ValueError):  # noqa: PT011
+        job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script,
+                            user_number=user_number, experiment_number=experiment_number)
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_simple_job_experiment_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    experiment_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.simple_job(runner_image=runner_image, script=script, experiment_number=experiment_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"runner_image": runner_image, "script": script,
+                                  "experiment_number": experiment_number})))
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_simple_job_user_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.simple_job(runner_image=runner_image, script=script, user_number=user_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"runner_image": runner_image, "script": script,
+                                  "user_number": user_number})))
+
+
+@mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
+def test_simple_job_user_and_experiment_number(broker):
+    job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = faker.generator.random.randint(1, 1000000)
+    experiment_number = faker.generator.random.randint(1, 1000000)
+
+    job_maker.simple_job(runner_image=runner_image, script=script,
+                         user_number=user_number, experiment_number=experiment_number)
+
+    assert broker.call_count == 1
+    assert broker.call_arg == mock.call()
+    assert job_maker._send_message.call_count == 1
+    assert (job_maker._send_message.call_args ==
+            mock.call(json.dumps({"runner_image": runner_image, "script": script,
+                                  "experiment_number": experiment_number})))
+
+
+def test_simple_job_user_and_experiment_number_is_none():
+    with mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker"):
+        job_maker = JobMaker("", "", "", "")
+    job_maker._send_message = mock.MagicMock()
+    runner_image = str(mock.MagicMock())
+    script = str(mock.MagicMock())
+    user_number = None
+    experiment_number = None
+
+    with pytest.raises(ValueError):  # noqa: PT011
+        job_maker.simple_job(runner_image=runner_image, script=script,
+                             user_number=user_number, experiment_number=experiment_number)

--- a/test/core/test_job_maker.py
+++ b/test/core/test_job_maker.py
@@ -8,6 +8,7 @@ from test.utils import FIA_FAKER_PROVIDER
 
 faker = FIA_FAKER_PROVIDER
 
+
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
 def test_send_message(broker):
     job_maker = JobMaker("", "", "", "")
@@ -36,9 +37,11 @@ def test_rerun_job_experiment_number(broker):
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
-                                  "experiment_number": experiment_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps(
+            {"job_id": job_id, "runner_image": runner_image, "script": script, "experiment_number": experiment_number}
+        )
+    )
 
 
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
@@ -55,9 +58,9 @@ def test_rerun_job_user_number(broker):
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
-                                  "user_number": user_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script, "user_number": user_number})
+    )
 
 
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
@@ -70,15 +73,22 @@ def test_rerun_job_user_and_experiment_number(broker):
     user_number = faker.generator.random.randint(1, 1000000)
     experiment_number = faker.generator.random.randint(1, 1000000)
 
-    job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script,
-                        user_number=user_number, experiment_number=experiment_number)
+    job_maker.rerun_job(
+        job_id=job_id,
+        runner_image=runner_image,
+        script=script,
+        user_number=user_number,
+        experiment_number=experiment_number,
+    )
 
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"job_id": job_id, "runner_image": runner_image, "script": script,
-                                  "experiment_number": experiment_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps(
+            {"job_id": job_id, "runner_image": runner_image, "script": script, "experiment_number": experiment_number}
+        )
+    )
 
 
 def test_rerun_job_user_and_experiment_number_is_none():
@@ -92,8 +102,13 @@ def test_rerun_job_user_and_experiment_number_is_none():
     experiment_number = None
 
     with pytest.raises(ValueError):  # noqa: PT011
-        job_maker.rerun_job(job_id=job_id, runner_image=runner_image, script=script,
-                            user_number=user_number, experiment_number=experiment_number)
+        job_maker.rerun_job(
+            job_id=job_id,
+            runner_image=runner_image,
+            script=script,
+            user_number=user_number,
+            experiment_number=experiment_number,
+        )
 
 
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
@@ -109,9 +124,9 @@ def test_simple_job_experiment_number(broker):
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"runner_image": runner_image, "script": script,
-                                  "experiment_number": experiment_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps({"runner_image": runner_image, "script": script, "experiment_number": experiment_number})
+    )
 
 
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
@@ -127,9 +142,9 @@ def test_simple_job_user_number(broker):
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"runner_image": runner_image, "script": script,
-                                  "user_number": user_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps({"runner_image": runner_image, "script": script, "user_number": user_number})
+    )
 
 
 @mock.patch("fia_api.core.job_maker.JobMaker._connect_to_broker")
@@ -141,15 +156,16 @@ def test_simple_job_user_and_experiment_number(broker):
     user_number = faker.generator.random.randint(1, 1000000)
     experiment_number = faker.generator.random.randint(1, 1000000)
 
-    job_maker.simple_job(runner_image=runner_image, script=script,
-                         user_number=user_number, experiment_number=experiment_number)
+    job_maker.simple_job(
+        runner_image=runner_image, script=script, user_number=user_number, experiment_number=experiment_number
+    )
 
     assert broker.call_count == 1
     assert broker.call_arg == mock.call()
     assert job_maker._send_message.call_count == 1
-    assert (job_maker._send_message.call_args ==
-            mock.call(json.dumps({"runner_image": runner_image, "script": script,
-                                  "experiment_number": experiment_number})))
+    assert job_maker._send_message.call_args == mock.call(
+        json.dumps({"runner_image": runner_image, "script": script, "experiment_number": experiment_number})
+    )
 
 
 def test_simple_job_user_and_experiment_number_is_none():
@@ -162,5 +178,6 @@ def test_simple_job_user_and_experiment_number_is_none():
     experiment_number = None
 
     with pytest.raises(ValueError):  # noqa: PT011
-        job_maker.simple_job(runner_image=runner_image, script=script,
-                             user_number=user_number, experiment_number=experiment_number)
+        job_maker.simple_job(
+            runner_image=runner_image, script=script, user_number=user_number, experiment_number=experiment_number
+        )

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  rabbit-mq:
+    image: "rabbitmq:3.12-management"
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 3
+    environment:
+      RABBITMQ_USER: guest
+      RABBITMQ_PASSWORD: guest

--- a/test/e2e/test_job_maker.py
+++ b/test/e2e/test_job_maker.py
@@ -1,0 +1,91 @@
+import json
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from pika.adapters.blocking_connection import BlockingChannel, BlockingConnection
+from starlette.testclient import TestClient
+
+from fia_api.fia_api import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def producer_channel() -> BlockingChannel:
+    """Consume producer channel fixture"""
+    connection = BlockingConnection()
+    channel = connection.channel()
+    channel.exchange_declare("scheduled-jobs", exchange_type="direct", durable=True)
+    channel.queue_declare("scheduled-jobs", durable=True, arguments={"x-queue-type": "quorum"})
+    channel.queue_bind("scheduled-jobs", "scheduled-jobs", routing_key="")
+    return channel
+
+
+@pytest.fixture(autouse=True)
+def _purge_queues(producer_channel):
+    """Purge queues on setup and teardown"""
+    yield
+    producer_channel.queue_purge(queue="scheduled-jobs")
+
+
+def consume_all_messages(consumer_channel: BlockingChannel) -> list[dict[str, Any]]:
+    """Consume all messages from the queue"""
+    received_messages = []
+    for mf, _, body in consumer_channel.consume("scheduled-jobs", inactivity_timeout=1):
+        if mf is None:
+            break
+
+        consumer_channel.basic_ack(mf.delivery_tag)
+        received_messages.append(json.loads(body.decode()))
+    return received_messages
+
+
+def produce_message(message: str, channel: BlockingChannel) -> None:
+    """
+    Given a message and a channel, produce the message to the queue on that channel
+    :param message: The message to produce
+    :param channel: The channel to produce to
+    :return: None
+    """
+    channel.basic_publish("scheduled-jobs", "", body=message.encode())
+
+
+def test_post_rerun_job(producer_channel):
+    rerun_body = {
+        "job_id": "1",
+        "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
+        "script": 'print("Hello World!")'
+    }
+
+    response = client.post("/job/rerun", json=rerun_body, headers={"Authorization": "Bearer shh"})
+
+    message = consume_all_messages(producer_channel)
+    assert response.status_code == HTTPStatus.OK
+    assert message == [
+        {
+            "experiment_number": 667500,
+            "job_id": 1,
+            "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
+            "script": 'print("Hello World!")'
+        }
+    ]
+
+
+def test_post_simple_job(producer_channel):
+    simple_body = {
+        "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
+        "script": 'print("Hello World!")'
+    }
+
+    response = client.post("/job/simple", json=simple_body, headers={"Authorization": "Bearer shh"})
+
+    message = consume_all_messages(producer_channel)
+    assert response.status_code == HTTPStatus.OK
+    assert message == [
+        {
+            "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
+            "script": 'print("Hello World!")',
+            "user_number": 123
+        }
+    ]

--- a/test/e2e/test_job_maker.py
+++ b/test/e2e/test_job_maker.py
@@ -55,7 +55,7 @@ def test_post_rerun_job(producer_channel):
     rerun_body = {
         "job_id": "1",
         "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
-        "script": 'print("Hello World!")'
+        "script": 'print("Hello World!")',
     }
 
     response = client.post("/job/rerun", json=rerun_body, headers={"Authorization": "Bearer shh"})
@@ -67,16 +67,13 @@ def test_post_rerun_job(producer_channel):
             "experiment_number": 667500,
             "job_id": 1,
             "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
-            "script": 'print("Hello World!")'
+            "script": 'print("Hello World!")',
         }
     ]
 
 
 def test_post_simple_job(producer_channel):
-    simple_body = {
-        "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
-        "script": 'print("Hello World!")'
-    }
+    simple_body = {"runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234", "script": 'print("Hello World!")'}
 
     response = client.post("/job/simple", json=simple_body, headers={"Authorization": "Bearer shh"})
 
@@ -86,6 +83,6 @@ def test_post_simple_job(producer_channel):
         {
             "runner_image": "ghcr.io/fiaisis/cool-runner@sha256:1234",
             "script": 'print("Hello World!")',
-            "user_number": 123
+            "user_number": 123,
         }
     ]


### PR DESCRIPTION
Closes #332

## Description
This is the culmination of a chunk of work around restructuring data models, and allowing jobs to be created by the FIA-API via the JobCreator

Adds 2 new endpoints.

/jobs/simple
/jobs/rerun

Both take arguments as part of the body. Both require both the runner_image and script inputs, then the rerun requires a job_id as well.