### PR TITLE
Add job type to responses

### DIFF
--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -99,6 +99,7 @@ class JobResponse(BaseModel):
     stacktrace: str | None
     script: ScriptResponse | None
     runner_image: str | None
+    type: str | None
 
     @staticmethod
     def from_job(job: Job) -> JobResponse:
@@ -119,6 +120,7 @@ class JobResponse(BaseModel):
             stacktrace=job.stacktrace,
             id=job.id,
             runner_image=job.runner_image,
+            type=str(job.job_type)
         )
 
 
@@ -149,4 +151,5 @@ class JobWithRunResponse(JobResponse):
             stacktrace=job.stacktrace,
             run=RunResponse.from_run(job.run) if isinstance(job.run, Run) else None,
             runner_image=job.runner_image,
+            type=str(job.job_type)
         )

--- a/fia_api/core/responses.py
+++ b/fia_api/core/responses.py
@@ -120,7 +120,7 @@ class JobResponse(BaseModel):
             stacktrace=job.stacktrace,
             id=job.id,
             runner_image=job.runner_image,
-            type=str(job.job_type)
+            type=str(job.job_type),
         )
 
 
@@ -151,5 +151,5 @@ class JobWithRunResponse(JobResponse):
             stacktrace=job.stacktrace,
             run=RunResponse.from_run(job.run) if isinstance(job.run, Run) else None,
             runner_image=job.runner_image,
-            type=str(job.job_type)
+            type=str(job.job_type),
         )

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -41,7 +41,7 @@ JOB = Job(
     script=SCRIPT,
     stacktrace="some stacktrace",
     run=RUN,
-    job_type=JobType.AUTOREDUCTION
+    job_type=JobType.AUTOREDUCTION,
 )
 
 

--- a/test/core/test_responses.py
+++ b/test/core/test_responses.py
@@ -6,7 +6,7 @@ import copy
 import datetime
 from unittest import mock
 
-from db.data_models import Instrument, Job, JobOwner, Run, Script, State
+from db.data_models import Instrument, Job, JobOwner, JobType, Run, Script, State
 
 from fia_api.core.responses import (
     JobResponse,
@@ -41,6 +41,7 @@ JOB = Job(
     script=SCRIPT,
     stacktrace="some stacktrace",
     run=RUN,
+    job_type=JobType.AUTOREDUCTION
 )
 
 
@@ -101,6 +102,7 @@ def test_job_response_from_job(from_script):
     assert response.outputs == JOB.outputs
     assert response.status_message == JOB.status_message
     assert response.stacktrace == JOB.stacktrace
+    assert response.type == str(JOB.job_type)
 
 
 @mock.patch(
@@ -123,6 +125,7 @@ def test_job_with_runs_response_from_job(from_script):
     assert response.outputs == JOB.outputs
     assert response.status_message == JOB.status_message
     assert response.run == RunResponse.from_run(JOB.run)
+    assert response.type == str(JOB.job_type)
 
 
 @mock.patch("fia_api.core.responses.filter_script_for_tokens", return_value=SCRIPT.script)

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -86,6 +86,7 @@ def test_get_all_job_for_user(mock_post, mock_get_experiment_numbers_for_user_nu
             "script": None,
             "stacktrace": None,
             "runner_image": None,
+            "type": "JobType.AUTOREDUCTION",
         }
     ]
 
@@ -133,6 +134,7 @@ def test_get_all_job_for_user_include_run(mock_post, mock_get_experiment_numbers
             "script": None,
             "stacktrace": None,
             "runner_image": None,
+            "type": "JobType.AUTOREDUCTION",
         }
     ]
 
@@ -179,6 +181,7 @@ def test_get_job_by_id_job_exists_for_staff(mock_post):
         "script": None,
         "stacktrace": None,
         "runner_image": None,
+        "type": "JobType.AUTOREDUCTION",
     }
 
 

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -288,6 +288,7 @@ def test_get_jobs_for_instrument_jobs_exist_for_dev_mode():
                 "script": None,
                 "stacktrace": None,
                 "runner_image": None,
+                "type": "JobType.AUTOREDUCTION"
             }
         ]
 
@@ -324,6 +325,7 @@ def test_get_jobs_for_instrument_jobs_exist_for_staff(mock_post):
             "script": None,
             "stacktrace": None,
             "runner_image": None,
+            "type": "JobType.AUTOREDUCTION"
         }
     ]
 
@@ -382,6 +384,7 @@ def test_get_jobs_for_instrument_runs_included_for_staff(mock_post):
             "script": None,
             "stacktrace": None,
             "runner_image": None,
+            "type": "JobType.AUTOREDUCTION"
         }
     ]
 

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -288,7 +288,7 @@ def test_get_jobs_for_instrument_jobs_exist_for_dev_mode():
                 "script": None,
                 "stacktrace": None,
                 "runner_image": None,
-                "type": "JobType.AUTOREDUCTION"
+                "type": "JobType.AUTOREDUCTION",
             }
         ]
 
@@ -325,7 +325,7 @@ def test_get_jobs_for_instrument_jobs_exist_for_staff(mock_post):
             "script": None,
             "stacktrace": None,
             "runner_image": None,
-            "type": "JobType.AUTOREDUCTION"
+            "type": "JobType.AUTOREDUCTION",
         }
     ]
 
@@ -384,7 +384,7 @@ def test_get_jobs_for_instrument_runs_included_for_staff(mock_post):
             "script": None,
             "stacktrace": None,
             "runner_image": None,
-            "type": "JobType.AUTOREDUCTION"
+            "type": "JobType.AUTOREDUCTION",
         }
     ]
 


### PR DESCRIPTION
Closes None, was completed as part of this PR's support: https://github.com/fiaisis/frontend/pull/276
## Description
Ensures that the jobtype is exposed to api calls.