### PR TITLE
Fix order_by param for all jobs

### DIFF
--- a/fia_api/core/specifications/job.py
+++ b/fia_api/core/specifications/job.py
@@ -137,3 +137,17 @@ class JobSpecification(Specification[Job]):
         self._apply_ordering(order_by, order_direction)
 
         return self
+
+    @paginate
+    def all(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        order_by: JointRunJobOrderField = "id",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> JobSpecification:
+        """"""
+        self.value = self.value.join(Run)
+        self._apply_ordering(order_by, order_direction)
+
+        return self

--- a/fia_api/core/specifications/job.py
+++ b/fia_api/core/specifications/job.py
@@ -146,7 +146,15 @@ class JobSpecification(Specification[Job]):
         order_by: JointRunJobOrderField = "id",
         order_direction: Literal["asc", "desc"] = "desc",
     ) -> JobSpecification:
-        """"""
+        """
+        Fetches all jobs and applies ordering, limit, and offset to the query.
+
+        :param limit: The maximum number of jobs to return. None indicates no limit.
+        :param offset: The number of jobs to skip before starting to return the results. None for no offset.
+        :param order_by: The attribute to order the jobs by. Can be attributes of Job or Run entities.
+        :param order_direction: The direction to order the jobs, either 'asc' for ascending or 'desc' for descending.
+        :return: An instance of JobSpecification with the applied filters and ordering.
+        """
         self.value = self.value.join(Run)
         self._apply_ordering(order_by, order_direction)
 

--- a/test/core/services/test_job.py
+++ b/test/core/services/test_job.py
@@ -185,6 +185,7 @@ def test_get_experiment_number_from_job_id_expect_raise(mock_repo):
     with patch("fia_api.core.services.job.JobSpecification"), pytest.raises(ValueError):  # noqa: PT011
         get_experiment_number_for_job_id(job_id)
 
+
 @patch("fia_api.core.services.job._REPO")
 @patch("fia_api.core.services.job.JobSpecification")
 def test_get_all_jobs_order_by_run_start_desc(mock_spec_class, mock_repo):
@@ -208,6 +209,7 @@ def test_get_all_jobs_order_by_run_start_asc(mock_spec_class, mock_repo):
     spec.all.assert_called_once_with(limit=5, offset=0, order_by="run_start", order_direction="asc")
     mock_repo.find.assert_called_once_with(spec.all())
 
+
 @patch("fia_api.core.services.job._REPO")
 @patch("fia_api.core.services.job.JobSpecification")
 def test_get_all_jobs_default_order_by_start(mock_spec_class, mock_repo):
@@ -218,6 +220,7 @@ def test_get_all_jobs_default_order_by_start(mock_spec_class, mock_repo):
     get_all_jobs(limit=5, offset=0)
     spec.all.assert_called_once_with(limit=5, offset=0, order_by="start", order_direction="desc")
     mock_repo.find.assert_called_once_with(spec.all())
+
 
 @patch("fia_api.core.services.job._REPO")
 @patch("fia_api.core.services.job.JobSpecification")

--- a/test/core/services/test_job.py
+++ b/test/core/services/test_job.py
@@ -184,3 +184,48 @@ def test_get_experiment_number_from_job_id_expect_raise(mock_repo):
 
     with patch("fia_api.core.services.job.JobSpecification"), pytest.raises(ValueError):  # noqa: PT011
         get_experiment_number_for_job_id(job_id)
+
+@patch("fia_api.core.services.job._REPO")
+@patch("fia_api.core.services.job.JobSpecification")
+def test_get_all_jobs_order_by_run_start_desc(mock_spec_class, mock_repo):
+    """
+    Test get_all_jobs with order_by 'run_start' in descending order.
+    """
+    spec = mock_spec_class.return_value
+    get_all_jobs(limit=5, offset=0, order_by="run_start", order_direction="desc")
+    spec.all.assert_called_once_with(limit=5, offset=0, order_by="run_start", order_direction="desc")
+    mock_repo.find.assert_called_once_with(spec.all())
+
+
+@patch("fia_api.core.services.job._REPO")
+@patch("fia_api.core.services.job.JobSpecification")
+def test_get_all_jobs_order_by_run_start_asc(mock_spec_class, mock_repo):
+    """
+    Test get_all_jobs with order_by 'run_start' in ascending order.
+    """
+    spec = mock_spec_class.return_value
+    get_all_jobs(limit=5, offset=0, order_by="run_start", order_direction="asc")
+    spec.all.assert_called_once_with(limit=5, offset=0, order_by="run_start", order_direction="asc")
+    mock_repo.find.assert_called_once_with(spec.all())
+
+@patch("fia_api.core.services.job._REPO")
+@patch("fia_api.core.services.job.JobSpecification")
+def test_get_all_jobs_default_order_by_start(mock_spec_class, mock_repo):
+    """
+    Test get_all_jobs without specifying a different order_by, per the function signature it should order by 'start'.
+    """
+    spec = mock_spec_class.return_value
+    get_all_jobs(limit=5, offset=0)
+    spec.all.assert_called_once_with(limit=5, offset=0, order_by="start", order_direction="desc")
+    mock_repo.find.assert_called_once_with(spec.all())
+
+@patch("fia_api.core.services.job._REPO")
+@patch("fia_api.core.services.job.JobSpecification")
+def test_get_all_jobs_with_pagination(mock_spec_class, mock_repo):
+    """
+    Test get_all_jobs with custom pagination (limit and offset).
+    """
+    spec = mock_spec_class.return_value
+    get_all_jobs(limit=15, offset=30)
+    spec.all.assert_called_once_with(limit=15, offset=30, order_by="start", order_direction="desc")
+    mock_repo.find.assert_called_once_with(spec.all())


### PR DESCRIPTION
Closes #359.

## Description

Adds a JobSpecification.all() method which applies ordering last. Should stop issues when fetching from the API using the "order_by" param,