### PR TITLE
Add as_user param

### DIFF
--- a/fia_api/router.py
+++ b/fia_api/router.py
@@ -124,6 +124,7 @@ async def get_jobs(
     order_by: OrderField = "start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_run: bool = False,
+    as_user: bool = False,
 ) -> list[JobResponse] | list[JobWithRunResponse]:
     """
     Retrieve all jobs.
@@ -136,10 +137,18 @@ async def get_jobs(
     "experiment_title", "filename",]
     :param order_direction: Literal["asc", "desc"]
     :param include_run: bool
+    :param as_user: bool
     :return: List of JobResponse objects
     """
     user = get_user_from_token(credentials.credentials)
-    user_number = None if user.role == "staff" else user.user_number
+
+    if as_user:
+        user_number = user.user_number
+    elif user.role == "staff":
+        user_number = None
+    else:
+        user_number = user.user_number
+
     jobs = get_all_jobs(
         limit=limit, offset=offset, order_by=order_by, order_direction=order_direction, user_number=user_number
     )
@@ -158,6 +167,7 @@ async def get_jobs_by_instrument(
     order_by: OrderField = "start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_run: bool = False,
+    as_user: bool = False,
 ) -> list[JobResponse] | list[JobWithRunResponse]:
     """
     Retrieve a list of jobs for a given instrument.
@@ -174,8 +184,16 @@ async def get_jobs_by_instrument(
     :return: List of JobResponse objects
     """
     user = get_user_from_token(credentials.credentials)
+
     instrument = instrument.upper()
-    user_number = None if user.role == "staff" else user.user_number
+
+    if as_user:
+        user_number = user.user_number
+    elif user.role == "staff":
+        user_number = None
+    else:
+        user_number = user.user_number
+
     jobs = get_job_by_instrument(
         instrument,
         limit=limit,

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -660,7 +660,7 @@ def test_get_mari_jobs_as_user_false_and_as_staff(mock_post):
     assert len(response.json()) > 1
 
 
-@patch("fia_api.core.specifcations.job.get_experiments_for_user_number")
+@patch("fia_api.core.specifications.job.get_experiments_for_user_number")
 def test_get_mari_jobs_as_user_true_and_as_staff_and_dev_mode_true(mock_get_experiment_numbers_for_user_number):
     """Test that being in dev mode makes no difference when getting MARI jobs with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -33,7 +33,7 @@ STAFF_TOKEN = (
 )
 
 TEST_JOB_OWNER = JobOwner(experiment_number=18204970)
-TEST_INSTRUMENT = Instrument(instrument_name="FOO", latest_run=1, specification={"foo": "bar"})
+TEST_INSTRUMENT = Instrument(instrument_name="NEWBIE", latest_run=1, specification={"foo": "bar"})
 TEST_SCRIPT = Script(script="print('Script 1')", sha="some_sha", script_hash="some_hash")
 TEST_JOB = Job(
     start=datetime.datetime.now(datetime.UTC),
@@ -662,7 +662,7 @@ def test_get_mari_jobs_as_user_true_and_as_staff(mock_post, mock_get_experiment_
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [18204970]
     mock_post.return_value.status_code = HTTPStatus.OK
-    response = client.get("/instrument/foo/jobs?&as_user=true", headers={"Authorization": f"Bearer {STAFF_TOKEN}"})
+    response = client.get("/instrument/newbie/jobs?&as_user=true", headers={"Authorization": f"Bearer {STAFF_TOKEN}"})
     assert response.status_code == HTTPStatus.OK
     assert len(response.json()) == 1
 

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -660,7 +660,7 @@ def test_get_mari_jobs_as_user_false_and_as_staff(mock_post):
 
 
 @patch("fia_api.core.services.job.get_experiments_for_user_number")
-def test_get_mari_jobs_as_user_false_and_as_staff_and_dev_mode_true(mock_get_experiment_numbers_for_user_number):
+def test_get_mari_jobs_as_user_true_and_as_staff_and_dev_mode_true(mock_get_experiment_numbers_for_user_number):
     """Test that being in dev mode makes no difference when getting MARI jobs with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]
     with patch("fia_api.core.auth.tokens.DEV_MODE", True):

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -638,7 +638,7 @@ def test_get_all_jobs_response_body_as_user_true_and_dev_mode_true(mock_get_expe
         ]
 
 
-@patch("fia_api.core.services.job.get_experiments_for_user_number")
+@patch("fia_api.core.specifcations.job.get_experiments_for_user_number")
 @patch("fia_api.core.auth.tokens.requests.post")
 def test_get_mari_jobs_as_user_true_and_as_staff(mock_post, mock_get_experiment_numbers_for_user_number):
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
@@ -660,7 +660,7 @@ def test_get_mari_jobs_as_user_false_and_as_staff(mock_post):
     assert len(response.json()) > 1
 
 
-@patch("fia_api.core.services.job.get_experiments_for_user_number")
+@patch("fia_api.core.specifcations.job.get_experiments_for_user_number")
 def test_get_mari_jobs_as_user_true_and_as_staff_and_dev_mode_true(mock_get_experiment_numbers_for_user_number):
     """Test that being in dev mode makes no difference when getting MARI jobs with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -639,7 +639,8 @@ def test_get_all_jobs_response_body_as_user_true_and_dev_mode_true(mock_get_expe
 
 
 @patch("fia_api.core.auth.tokens.requests.post")
-def test_get_mari_jobs_as_user_true_and_as_staff(mock_post):
+@patch("fia_api.core.services.job.get_experiments_for_user_number")
+def test_get_mari_jobs_as_user_true_and_as_staff(mock_post, mock_get_experiment_numbers_for_user_number):
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
     mock_post.return_value.status_code = HTTPStatus.OK
     response = client.get("/instrument/mari/jobs?&as_user=true", headers={"Authorization": f"Bearer {STAFF_TOKEN}"})

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -683,7 +683,8 @@ def test_get_mari_jobs_as_user_false_and_as_staff(mock_post):
 def test_multiple_get_job_requests_with_different_as_user_values(
     mock_post, mock_get_experiment_numbers_for_user_number
 ):
-    """Test get all jobs with as_user flag set to true and false for a staff user yield responses of different lengths"""
+    """Test get all jobs with as_user flag set to true and false for a staff
+    user yield responses of different lengths"""
     mock_post.return_value.status_code = HTTPStatus.OK
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]
 

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -466,7 +466,7 @@ def test_jobs_count():
     """
     response = client.get("/jobs/count")
     assert response.status_code == HTTPStatus.OK
-    assert response.json()["count"] == 5001  # noqa: PLR2004
+    assert response.json()["count"] == 5002  # noqa: PLR2004
 
 
 @patch("fia_api.core.auth.tokens.requests.post")

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -638,8 +638,8 @@ def test_get_all_jobs_response_body_as_user_true_and_dev_mode_true(mock_get_expe
         ]
 
 
-@patch("fia_api.core.auth.tokens.requests.post")
 @patch("fia_api.core.services.job.get_experiments_for_user_number")
+@patch("fia_api.core.auth.tokens.requests.post")
 def test_get_mari_jobs_as_user_true_and_as_staff(mock_post, mock_get_experiment_numbers_for_user_number):
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -9,10 +9,10 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from db.data_models import Base, Instrument, Job, JobOwner, JobType, Run, Script, State
+from db.data_models import Instrument, Job, JobOwner, JobType, Run, Script, State
 from starlette.testclient import TestClient
 
-from fia_api.core.repositories import ENGINE, SESSION
+from fia_api.core.repositories import SESSION
 from fia_api.fia_api import app
 from test.utils import FIA_FAKER_PROVIDER
 
@@ -58,15 +58,12 @@ TEST_RUN = Run(
 TEST_RUN.jobs.append(TEST_JOB)
 
 
-@pytest.fixture(autouse=True)
-def user_owned_data_setup() -> None:
+@pytest.fixture()
+def _user_owned_data_setup() -> None:
     """
     Set up the test database before module
     :return: None
     """
-    Base.metadata.drop_all(ENGINE)
-    Base.metadata.create_all(ENGINE)
-
     with SESSION() as session:
         session.add(TEST_SCRIPT)
         session.add(TEST_INSTRUMENT)
@@ -687,10 +684,10 @@ def test_get_all_jobs_response_body_as_user_true_and_dev_mode_true(mock_get_expe
         ]
 
 
-@patch("fia_api.core.specifcations.job.get_experiments_for_user_number")
+@patch("fia_api.core.specifications.job.get_experiments_for_user_number")
 @patch("fia_api.core.auth.tokens.requests.post")
 def test_get_mari_jobs_as_user_true_and_as_staff(
-    mock_post, mock_get_experiment_numbers_for_user_number, user_owned_data_setup
+    mock_post, mock_get_experiment_numbers_for_user_number, _user_owned_data_setup
 ):
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -600,7 +600,7 @@ def test_get_all_jobs_as_user_false_and_as_staff(mock_post, mock_get_experiment_
     mock_get_experiment_numbers_for_user_number.return_value = [1820497]
     response = client.get("/jobs?limit=10&as_user=false", headers={"Authorization": f"Bearer {STAFF_TOKEN}"})
     assert response.status_code == HTTPStatus.OK
-    assert response.json() > 1
+    assert len(response.json()) > 1
 
 
 @patch("fia_api.core.services.job.get_experiments_for_user_number")

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -642,6 +642,7 @@ def test_get_all_jobs_response_body_as_user_true_and_dev_mode_true(mock_get_expe
 @patch("fia_api.core.services.job.get_experiments_for_user_number")
 def test_get_mari_jobs_as_user_true_and_as_staff(mock_post, mock_get_experiment_numbers_for_user_number):
     """Test that a single job is returned when a staff user gets jobs from MARI with the as_user flag set to true"""
+    mock_get_experiment_numbers_for_user_number.return_value = [1820497]
     mock_post.return_value.status_code = HTTPStatus.OK
     response = client.get("/instrument/mari/jobs?&as_user=true", headers={"Authorization": f"Bearer {STAFF_TOKEN}"})
     assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
Closes #FIAISIS/frontend#357

## Description

Adds a `as_user` flag to the jobs endpoint which when true ignores whether the request was made by staff or not.