### PR TITLE
Use correct tag

### DIFF
--- a/fia_api/routers/find_file.py
+++ b/fia_api/routers/find_file.py
@@ -14,7 +14,7 @@ from fia_api.core.utility import (
     request_path_check,
 )
 
-FindFileRouter = APIRouter(prefix="/find_file", tags=["files"])
+FindFileRouter = APIRouter(prefix="/find_file", tags=["find_files"])
 
 jwt_api_security = JWTAPIBearer()
 


### PR DESCRIPTION
Closes None.

## Description

Think the APIRouter tag should be the same as for the function decorators otherwise appears as two separate groups in the fastapi.
